### PR TITLE
Add FastAPI/Streamlit deployment stack for predictive maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,68 @@ This project aims to build a **predictive maintenance system** using **machine l
 - **Power BI / Tableau** → Dashboard visualization
 - **Docker & API** → Deployment & accessibility
 
+## 🚢 Running the API & Frontend Stack
+
+The repository ships with a FastAPI service (`deployment/API_endpoint.py`) and a Streamlit UI (`frontend/streamlit_app.py`). Both
+components are packaged together through the Dockerfile in `deployment/`.
+
+### Prerequisites
+
+- Docker 24+
+- (Optional) An external SQL database that exposes the `engine_predictions`, `kpi_trends`, and `kpi_aggregates` tables/views. If not
+  supplied the stack falls back to the bundled sample dataset located at `deployment/sample_data.json`.
+
+### Environment Variables
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `PREDICTIVE_API_KEY` | Shared secret expected in the `X-API-Key` header for `/predict`, `/metrics`, `/reload`. | `dev-secret` |
+| `PREDICTIVE_API_BASE_URL` | Base URL the Streamlit client uses to reach the API. | `http://localhost:8000` |
+| `DATABASE_URL` | Optional SQLAlchemy connection string for production data. | *(unset)* |
+
+### Build & Run with Docker
+
+```bash
+docker build -t predictive-maintenance -f deployment/Dockerfile .
+docker run \
+  -p 8000:8000 \
+  -p 8501:8501 \
+  -e PREDICTIVE_API_KEY="your-strong-secret" \
+  -e PREDICTIVE_API_BASE_URL="http://localhost:8000" \
+  predictive-maintenance
+```
+
+- The FastAPI service is exposed at **http://localhost:8000** (health check at `/health`).
+- The Streamlit dashboard is available at **http://localhost:8501**.
+
+To point the service at a managed database, supply a `DATABASE_URL` (e.g. `postgresql+psycopg://user:pass@host:5432/db`). The
+expected schema is documented in `deployment/API_endpoint.py`.
+
+### Authenticating Requests
+
+All non-health endpoints require an API key supplied through the `X-API-Key` header. Use the same secret for local development and
+the container runtime:
+
+```bash
+curl \
+  -H "X-API-Key: your-strong-secret" \
+  http://localhost:8000/predict
+```
+
+If a key is not provided or mismatched, the service returns **401 Unauthorized**.
+
+### Local Development
+
+To run the stack without Docker make sure the dependencies in `deployment/requirements.txt` are installed, then execute in separate
+terminals:
+
+```bash
+uvicorn deployment.API_endpoint:app --reload --port 8000
+streamlit run frontend/streamlit_app.py --server.port 8501
+```
+
+Update the `PREDICTIVE_API_BASE_URL` environment variable if the API is hosted elsewhere.
+
 ## 📝 Documentation & Portfolio Links
 - **[GitHub Repository](#)** (Code & Implementation)
 - **[Power BI/Tableau Dashboard](#)** (Live KPI Dashboard)

--- a/deployment/API_endpoint.py
+++ b/deployment/API_endpoint.py
@@ -1,1 +1,309 @@
- 
+"""FastAPI service exposing turbine predictive maintenance insights.
+
+The service pulls model outputs from a SQL database when available, with a
+fallback to static JSON sample data for local development. It provides three
+endpoints:
+
+- ``/health`` for liveness checks.
+- ``/predict`` returning Remaining Useful Life (RUL), failure probabilities and
+  alerts per engine.
+- ``/metrics`` serving KPI aggregates and trend series for dashboarding.
+
+Authentication is handled through an ``X-API-Key`` header whose expected value is
+configured via the ``PREDICTIVE_API_KEY`` environment variable (defaults to a
+local development key).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from fastapi import Depends, FastAPI, Header, HTTPException, status
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class EnginePrediction(BaseModel):
+    engine_id: str = Field(..., description="Unique identifier for the engine")
+    cycle: int = Field(..., ge=0, description="Latest observed operating cycle")
+    rul: float = Field(..., ge=0, description="Remaining Useful Life estimate in cycles")
+    failure_probability: float = Field(
+        ..., ge=0, le=1, description="Probability of failure in the next prediction window"
+    )
+    alert_level: str = Field(..., description="Alert level derived from probability thresholds")
+    timestamp: datetime = Field(
+        ..., description="Timestamp when the prediction was generated or observed"
+    )
+
+
+class EngineTrend(BaseModel):
+    engine_id: str
+    timestamp: datetime
+    rul: float
+    failure_probability: float
+
+
+class KPIAggregates(BaseModel):
+    production_efficiency: float = Field(..., description="Overall production efficiency percentage")
+    failure_rate: float = Field(..., description="Fleet failure rate percentage")
+    mean_time_to_failure: float = Field(..., description="Mean cycles until failure")
+    average_rul: float = Field(..., description="Average RUL across the fleet")
+    downtime_cost: float = Field(..., description="Estimated downtime cost in USD per hour")
+
+
+class KPITrend(BaseModel):
+    metric: str
+    timestamp: datetime
+    value: float
+
+
+class PredictResponse(BaseModel):
+    generated_at: datetime
+    engines: List[EnginePrediction]
+
+
+class MetricsResponse(BaseModel):
+    generated_at: datetime
+    aggregates: KPIAggregates
+    kpi_trends: List[KPITrend]
+    engine_trends: List[EngineTrend]
+
+
+class DataRepository:
+    """Interface to load predictive maintenance outputs.
+
+    The repository first attempts to pull data from a SQL database defined by the
+    ``DATABASE_URL`` environment variable. When unavailable it falls back to a
+    JSON file bundled with the project to provide sample responses that power the
+    API and UI during local development.
+    """
+
+    def __init__(self, sample_path: Path, database_url: Optional[str] = None) -> None:
+        self.sample_path = sample_path
+        self.database_url = database_url or os.getenv("DATABASE_URL")
+        self._data = {}
+        self._load_data()
+
+    def _load_data(self) -> None:
+        if self.database_url and self._load_from_database():
+            logger.info("Loaded predictive outputs from database at %s", self.database_url)
+            return
+
+        self._load_from_sample()
+        logger.info("Loaded predictive outputs from sample dataset at %s", self.sample_path)
+
+    def _load_from_database(self) -> bool:
+        """Attempt to load data from a SQL database.
+
+        The method expects two tables:
+            - ``engine_predictions`` with columns ``engine_id``, ``cycle``, ``rul``,
+              ``failure_probability``, ``alert_level`` and ``timestamp``.
+            - ``kpi_trends`` with columns ``metric``, ``timestamp`` and ``value``.
+
+        It should also expose a ``kpi_aggregates`` view/table with one row containing
+        aggregate KPI columns. When the schema is missing or the driver is not
+        installed the method returns ``False`` which triggers the JSON fallback.
+        """
+
+        try:
+            from sqlalchemy import create_engine, text
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logger.warning("SQLAlchemy not available, falling back to sample data: %s", exc)
+            return False
+
+        engine = create_engine(self.database_url, future=True)
+
+        try:
+            with engine.connect() as connection:
+                prediction_rows = connection.execute(
+                    text(
+                        """
+                        SELECT engine_id, cycle, rul, failure_probability, alert_level, timestamp
+                        FROM engine_predictions
+                        ORDER BY timestamp DESC
+                        """
+                    )
+                ).mappings()
+                kpi_trend_rows = connection.execute(
+                    text(
+                        """
+                        SELECT metric, timestamp, value
+                        FROM kpi_trends
+                        ORDER BY timestamp
+                        """
+                    )
+                ).mappings()
+                aggregates_row = connection.execute(
+                    text("SELECT * FROM kpi_aggregates LIMIT 1")
+                ).mappings().first()
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logger.warning("Database unavailable or schema missing, using sample data: %s", exc)
+            return False
+
+        if aggregates_row is None:
+            logger.warning("kpi_aggregates table is empty; reverting to sample dataset")
+            return False
+
+        generated_at = datetime.utcnow()
+        self._data = {
+            "generated_at": generated_at.isoformat(),
+            "engines": list(prediction_rows),
+            "engine_trends": list(prediction_rows),
+            "kpi_trends": list(kpi_trend_rows),
+            "kpi_aggregates": dict(aggregates_row),
+        }
+        return True
+
+    def _load_from_sample(self) -> None:
+        with self.sample_path.open("r", encoding="utf-8") as handle:
+            self._data = json.load(handle)
+
+    def reload(self) -> None:
+        """Force a reload which picks up DB changes or refreshed sample data."""
+
+        self._load_data()
+
+    def _iter_engines(self, engine_id: Optional[str] = None) -> Iterable[Dict[str, object]]:
+        engines: List[Dict[str, object]] = self._data.get("engines", [])
+        for engine in engines:
+            if engine_id and engine.get("engine_id") != engine_id:
+                continue
+            yield engine
+
+    def get_predictions(self, engine_id: Optional[str] = None) -> List[EnginePrediction]:
+        predictions: List[EnginePrediction] = []
+        for engine in self._iter_engines(engine_id):
+            timestamp = engine.get("timestamp") or self._data.get("generated_at")
+            predictions.append(
+                EnginePrediction(
+                    engine_id=str(engine["engine_id"]),
+                    cycle=int(engine.get("cycle", 0)),
+                    rul=float(engine.get("rul", 0)),
+                    failure_probability=float(engine.get("failure_probability", 0)),
+                    alert_level=str(engine.get("alert_level", "normal")),
+                    timestamp=_parse_datetime(timestamp),
+                )
+            )
+        return predictions
+
+    def get_engine_trends(self, engine_id: Optional[str] = None) -> List[EngineTrend]:
+        trend_items: List[Dict[str, object]] = self._data.get("engine_trends", [])
+        results: List[EngineTrend] = []
+        for item in trend_items:
+            if engine_id and item.get("engine_id") != engine_id:
+                continue
+            results.append(
+                EngineTrend(
+                    engine_id=str(item["engine_id"]),
+                    timestamp=_parse_datetime(item["timestamp"]),
+                    rul=float(item.get("rul", 0)),
+                    failure_probability=float(item.get("failure_probability", 0)),
+                )
+            )
+        return results
+
+    def get_metrics(self) -> KPIAggregates:
+        aggregates = self._data.get("kpi_aggregates", {})
+        return KPIAggregates(
+            production_efficiency=float(aggregates.get("production_efficiency", 0)),
+            failure_rate=float(aggregates.get("failure_rate", 0)),
+            mean_time_to_failure=float(aggregates.get("mean_time_to_failure", 0)),
+            average_rul=float(aggregates.get("average_rul", 0)),
+            downtime_cost=float(aggregates.get("downtime_cost", 0)),
+        )
+
+    def get_kpi_trends(self) -> List[KPITrend]:
+        return [
+            KPITrend(
+                metric=str(item["metric"]),
+                timestamp=_parse_datetime(item["timestamp"]),
+                value=float(item.get("value", 0)),
+            )
+            for item in self._data.get("kpi_trends", [])
+        ]
+
+    def generated_at(self) -> datetime:
+        return _parse_datetime(self._data.get("generated_at", datetime.utcnow().isoformat()))
+
+
+def _parse_datetime(value: str | datetime | None) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            logger.warning("Unable to parse datetime %s; falling back to utcnow", value)
+    return datetime.utcnow()
+
+
+def get_repository() -> DataRepository:
+    sample_path = Path(__file__).resolve().parent / "sample_data.json"
+    return DataRepository(sample_path=sample_path)
+
+
+def verify_api_key(x_api_key: str = Header(default="")) -> None:
+    expected_key = os.getenv("PREDICTIVE_API_KEY", "dev-secret")
+    if not expected_key:
+        logger.warning("API key expected but not configured; rejecting request")
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="API key not configured")
+    if x_api_key != expected_key:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+
+
+app = FastAPI(title="Predictive Maintenance Service", version="1.0.0")
+
+
+@app.get("/health")
+def health_check() -> Dict[str, str]:
+    """Simple health endpoint used for readiness checks."""
+
+    return {"status": "ok"}
+
+
+@app.get("/predict", response_model=PredictResponse)
+def get_predictions(
+    engine_id: Optional[str] = None,
+    repo: DataRepository = Depends(get_repository),
+    _: None = Depends(verify_api_key),
+) -> PredictResponse:
+    """Return the latest predictions for each engine, optionally filtered."""
+
+    predictions = repo.get_predictions(engine_id=engine_id)
+    if engine_id and not predictions:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Engine not found")
+    return PredictResponse(generated_at=repo.generated_at(), engines=predictions)
+
+
+@app.get("/metrics", response_model=MetricsResponse)
+def get_metrics(
+    engine_id: Optional[str] = None,
+    repo: DataRepository = Depends(get_repository),
+    _: None = Depends(verify_api_key),
+) -> MetricsResponse:
+    """Return aggregated KPIs and trend data used by dashboards."""
+
+    aggregates = repo.get_metrics()
+    engine_trends = repo.get_engine_trends(engine_id=engine_id)
+    kpi_trends = repo.get_kpi_trends()
+    return MetricsResponse(
+        generated_at=repo.generated_at(),
+        aggregates=aggregates,
+        kpi_trends=kpi_trends,
+        engine_trends=engine_trends,
+    )
+
+
+@app.post("/reload", status_code=status.HTTP_204_NO_CONTENT)
+def reload_data(repo: DataRepository = Depends(get_repository), _: None = Depends(verify_api_key)) -> None:
+    """Hot-reload the backing datastore.
+
+    Useful for development when the SQL source or JSON fixture has changed.
+    """
+
+    repo.reload()

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,1 +1,24 @@
- 
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install system dependencies required by pandas/plotly
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY deployment/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY . /app
+
+ENV PREDICTIVE_API_KEY=dev-secret \
+    PREDICTIVE_API_BASE_URL=http://localhost:8000
+
+EXPOSE 8000 8501
+
+CMD ["bash", "-c", "uvicorn deployment.API_endpoint:app --host 0.0.0.0 --port 8000 & streamlit run frontend/streamlit_app.py --server.port 8501 --server.address 0.0.0.0"]

--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+streamlit==1.32.2
+pandas==2.2.1
+plotly==5.19.0
+requests==2.31.0
+sqlalchemy==2.0.25

--- a/deployment/sample_data.json
+++ b/deployment/sample_data.json
@@ -1,0 +1,55 @@
+{
+  "generated_at": "2024-06-01T12:00:00Z",
+  "engines": [
+    {
+      "engine_id": "FD001",
+      "cycle": 180,
+      "rul": 120,
+      "failure_probability": 0.05,
+      "alert_level": "normal"
+    },
+    {
+      "engine_id": "FD002",
+      "cycle": 220,
+      "rul": 72,
+      "failure_probability": 0.22,
+      "alert_level": "warning"
+    },
+    {
+      "engine_id": "FD003",
+      "cycle": 305,
+      "rul": 34,
+      "failure_probability": 0.41,
+      "alert_level": "critical"
+    }
+  ],
+  "engine_trends": [
+    {"engine_id": "FD001", "timestamp": "2024-05-20T00:00:00Z", "rul": 145, "failure_probability": 0.03},
+    {"engine_id": "FD001", "timestamp": "2024-05-25T00:00:00Z", "rul": 135, "failure_probability": 0.04},
+    {"engine_id": "FD001", "timestamp": "2024-05-30T00:00:00Z", "rul": 125, "failure_probability": 0.05},
+    {"engine_id": "FD002", "timestamp": "2024-05-20T00:00:00Z", "rul": 105, "failure_probability": 0.15},
+    {"engine_id": "FD002", "timestamp": "2024-05-25T00:00:00Z", "rul": 90, "failure_probability": 0.18},
+    {"engine_id": "FD002", "timestamp": "2024-05-30T00:00:00Z", "rul": 80, "failure_probability": 0.21},
+    {"engine_id": "FD003", "timestamp": "2024-05-20T00:00:00Z", "rul": 60, "failure_probability": 0.32},
+    {"engine_id": "FD003", "timestamp": "2024-05-25T00:00:00Z", "rul": 48, "failure_probability": 0.36},
+    {"engine_id": "FD003", "timestamp": "2024-05-30T00:00:00Z", "rul": 38, "failure_probability": 0.4}
+  ],
+  "kpi_aggregates": {
+    "production_efficiency": 92.5,
+    "failure_rate": 1.8,
+    "mean_time_to_failure": 640,
+    "average_rul": 108,
+    "downtime_cost": 4200
+  },
+  "kpi_trends": [
+    {"metric": "production_efficiency", "timestamp": "2024-05-20T00:00:00Z", "value": 91.3},
+    {"metric": "production_efficiency", "timestamp": "2024-05-25T00:00:00Z", "value": 92.0},
+    {"metric": "production_efficiency", "timestamp": "2024-05-30T00:00:00Z", "value": 92.5},
+    {"metric": "failure_rate", "timestamp": "2024-05-20T00:00:00Z", "value": 1.5},
+    {"metric": "failure_rate", "timestamp": "2024-05-25T00:00:00Z", "value": 1.6},
+    {"metric": "failure_rate", "timestamp": "2024-05-30T00:00:00Z", "value": 1.8},
+    {"metric": "downtime_cost", "timestamp": "2024-05-20T00:00:00Z", "value": 3800},
+    {"metric": "downtime_cost", "timestamp": "2024-05-25T00:00:00Z", "value": 4000},
+    {"metric": "downtime_cost", "timestamp": "2024-05-30T00:00:00Z", "value": 4200}
+  ]
+}

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -1,0 +1,165 @@
+"""Streamlit dashboard for turbine predictive maintenance insights."""
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import pandas as pd
+import plotly.express as px
+import requests
+import streamlit as st
+
+API_BASE_URL = os.getenv("PREDICTIVE_API_BASE_URL", "http://localhost:8000")
+API_KEY = os.getenv("PREDICTIVE_API_KEY", "dev-secret")
+REQUEST_TIMEOUT = int(os.getenv("PREDICTIVE_API_TIMEOUT", "10"))
+
+
+def _headers() -> Dict[str, str]:
+    return {"X-API-Key": API_KEY}
+
+
+@st.cache_data(ttl=30)
+def fetch_predictions(engine_id: Optional[str] = None) -> Dict:
+    params = {"engine_id": engine_id} if engine_id else {}
+    response = requests.get(
+        f"{API_BASE_URL}/predict", params=params, headers=_headers(), timeout=REQUEST_TIMEOUT
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+@st.cache_data(ttl=30)
+def fetch_metrics(engine_id: Optional[str] = None) -> Dict:
+    params = {"engine_id": engine_id} if engine_id else {}
+    response = requests.get(
+        f"{API_BASE_URL}/metrics", params=params, headers=_headers(), timeout=REQUEST_TIMEOUT
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _format_timestamp(timestamp: str) -> str:
+    return datetime.fromisoformat(timestamp.replace("Z", "+00:00")).strftime("%Y-%m-%d %H:%M")
+
+
+def render_kpi_cards(aggregates: Dict[str, float]) -> None:
+    st.subheader("Key Performance Indicators")
+    cols = st.columns(5)
+    cols[0].metric("Production Efficiency", f"{aggregates['production_efficiency']:.1f}%")
+    cols[1].metric("Failure Rate", f"{aggregates['failure_rate']:.1f}%")
+    cols[2].metric("MTTF", f"{aggregates['mean_time_to_failure']:.0f} cycles")
+    cols[3].metric("Average RUL", f"{aggregates['average_rul']:.0f} cycles")
+    cols[4].metric("Downtime Cost", f"${aggregates['downtime_cost']:,.0f}/hr")
+
+
+def render_engine_alerts(engines: List[Dict]) -> None:
+    critical = [e for e in engines if e["failure_probability"] >= 0.35]
+    warning = [e for e in engines if 0.2 <= e["failure_probability"] < 0.35]
+
+    if critical:
+        names = ", ".join(e["engine_id"] for e in critical)
+        st.error(f"⚠️ Critical failure risk detected for: {names}")
+    if warning:
+        names = ", ".join(e["engine_id"] for e in warning)
+        st.warning(f"⚠️ Elevated failure probability for: {names}")
+    if not critical and not warning:
+        st.success("All monitored engines are operating within acceptable thresholds.")
+
+
+def render_engine_trends(trends: List[Dict], engine_id: Optional[str]) -> None:
+    if not trends:
+        st.info("No trend data available for the selected engine yet.")
+        return
+
+    df = pd.DataFrame(trends)
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+
+    title_suffix = f" - Engine {engine_id}" if engine_id else " - Fleet"
+
+    fig_rul = px.line(
+        df,
+        x="timestamp",
+        y="rul",
+        color="engine_id",
+        markers=True,
+        title=f"Remaining Useful Life Trend{title_suffix}",
+    )
+    fig_rul.update_layout(yaxis_title="RUL (cycles)")
+
+    fig_failure = px.line(
+        df,
+        x="timestamp",
+        y="failure_probability",
+        color="engine_id",
+        markers=True,
+        title=f"Failure Probability Trend{title_suffix}",
+    )
+    fig_failure.update_layout(yaxis_title="Failure Probability", yaxis_tickformat=".0%")
+
+    st.plotly_chart(fig_rul, use_container_width=True)
+    st.plotly_chart(fig_failure, use_container_width=True)
+
+
+def render_kpi_trends(trends: List[Dict]) -> None:
+    if not trends:
+        return
+
+    df = pd.DataFrame(trends)
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    for metric, metric_df in df.groupby("metric"):
+        fig = px.line(
+            metric_df,
+            x="timestamp",
+            y="value",
+            markers=True,
+            title=f"{metric.replace('_', ' ').title()} Trend",
+        )
+        st.plotly_chart(fig, use_container_width=True)
+
+
+st.set_page_config(page_title="Predictive Maintenance Dashboard", layout="wide")
+st.title("Turbine Health & KPI Overview")
+
+st.sidebar.header("Configuration")
+st.sidebar.write(f"API Base URL: {API_BASE_URL}")
+
+try:
+    metrics_data = fetch_metrics()
+    predict_data = fetch_predictions()
+except requests.HTTPError as exc:
+    st.error(f"API responded with an error: {exc}")
+    st.stop()
+except requests.RequestException as exc:
+    st.error(f"Unable to reach the API endpoint: {exc}")
+    st.stop()
+
+engines = predict_data.get("engines", [])
+engine_options = ["All engines"] + [engine["engine_id"] for engine in engines]
+selected_engine = st.sidebar.selectbox("Select Engine", engine_options)
+
+if selected_engine != "All engines":
+    metrics_data = fetch_metrics(selected_engine)
+    predict_data = fetch_predictions(selected_engine)
+    engines = predict_data.get("engines", [])
+
+st.caption(f"Last updated: {_format_timestamp(metrics_data['generated_at'])}")
+
+render_engine_alerts(engines)
+render_kpi_cards(metrics_data["aggregates"])
+
+st.subheader("Engine Performance")
+render_engine_trends(
+    metrics_data.get("engine_trends", []), None if selected_engine == "All engines" else selected_engine
+)
+
+st.subheader("Fleet KPI Trends")
+render_kpi_trends(metrics_data.get("kpi_trends", []))
+
+st.subheader("Engine Snapshot")
+if engines:
+    engine_df = pd.DataFrame(engines)
+    engine_df["timestamp"] = pd.to_datetime(engine_df["timestamp"]).dt.tz_localize(None)
+    st.dataframe(engine_df.set_index("engine_id"))
+else:
+    st.info("No engine predictions found for the selected filter.")


### PR DESCRIPTION
## Summary
- implement a FastAPI service that serves prediction, KPI, and metrics endpoints with API key protection
- add a Streamlit dashboard that consumes the API and renders KPI cards, alert banners, and trend charts
- extend the Docker image, sample data, and documentation so the API and UI run together with clear launch instructions

## Testing
- python -m compileall deployment frontend

------
https://chatgpt.com/codex/tasks/task_e_690b8508aa7483329fa3e96b6fe43c48